### PR TITLE
Implement basic fund ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 *.egg-info/
 .env
 .DS_Store
+fund_state.json

--- a/README.md
+++ b/README.md
@@ -22,15 +22,25 @@
 ```
 
 ## 사용 방법
-1. Poetry 설치
+1. **UV 설치**
    ```bash
-   pipx install poetry
+   pipx install uv
    ```
-2. 의존성 설치
+2. **의존성 설치 및 가상환경 생성**
    ```bash
-   poetry install
+   uv venv
+   uv pip install -e .[dev]
    ```
-3. CLI 실행
+3. **CLI 실행**
    ```bash
-   poetry run defi-cli --help
+   source .venv/bin/activate
+   defi-cli --help
    ```
+
+### 예시 사용법
+```bash
+# 10 토큰 예치 후 5 지분 상환
+defi-cli deposit 10
+defi-cli withdraw 5
+defi-cli info
+```

--- a/src/defi_fund/cli/app.py
+++ b/src/defi_fund/cli/app.py
@@ -1,26 +1,45 @@
-import typer, sys
+import typer
 from loguru import logger
-from defi_fund.config import settings
+from defi_fund.state import load_state, save_state
 
 app = typer.Typer(help="DeFi Fund CLI")
 
 
 @app.command("deposit")
 def deposit(amount: float):
-    """예치 기능 (Mock)."""
-    logger.info(f"Depositing {amount} tokens (mock)")
+    """예치 기능: 자산을 예치하고 지분을 발행합니다."""
+    state = load_state()
+    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
+    new_shares = amount / price
+    state["total_assets"] += amount
+    state["total_shares"] += new_shares
+    save_state(state)
+    typer.echo(f"Deposited {amount} tokens -> {new_shares:.4f} shares")
 
 
 @app.command("withdraw")
 def withdraw(shares: float):
-    """출금 기능 (Mock)."""
-    logger.info(f"Withdrawing {shares} shares (mock)")
+    """출금 기능: 보유 지분을 상환합니다."""
+    state = load_state()
+    if shares > state["total_shares"]:
+        typer.echo("Not enough shares", err=True)
+        raise typer.Exit(code=1)
+    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
+    amount = shares * price
+    state["total_assets"] -= amount
+    state["total_shares"] -= shares
+    save_state(state)
+    typer.echo(f"Withdrew {shares} shares -> {amount:.4f} tokens")
 
 
 @app.command("info")
 def info():
-    """펀드 정보 조회 (Mock)."""
-    typer.echo("Fund NAV: 0.0 (mock)")
+    """펀드 정보 조회."""
+    state = load_state()
+    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
+    typer.echo(
+        f"Assets: {state['total_assets']:.4f}, Shares: {state['total_shares']:.4f}, Price: {price:.4f}"
+    )
 
 
 if __name__ == "__main__":

--- a/src/defi_fund/state.py
+++ b/src/defi_fund/state.py
@@ -1,0 +1,28 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+from .config import settings
+
+DEFAULT_STATE = {"total_assets": 0.0, "total_shares": 0.0}
+
+
+def get_state_file() -> Path:
+    """Return the path to the state file (evaluated lazily)."""
+    return Path(os.getenv("FUND_STATE_FILE", str(settings.BASE_DIR / "fund_state.json")))
+
+
+def load_state() -> Dict[str, float]:
+    state_file = get_state_file()
+    if state_file.exists():
+        with open(state_file) as f:
+            return json.load(f)
+    return DEFAULT_STATE.copy()
+
+
+def save_state(state: Dict[str, float]) -> None:
+    state_file = get_state_file()
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(state_file, "w") as f:
+        json.dump(state, f)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,17 @@
+import os
 import pytest
 from defi_fund.cli.app import deposit, withdraw
+from defi_fund.state import load_state
 
-def test_deposit_and_withdraw(capsys):
-    deposit(1.0)
-    withdraw(0.5)
+def test_deposit_and_withdraw(tmp_path, capsys, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("FUND_STATE_FILE", str(state_file))
+
+    deposit(10.0)
+    withdraw(5.0)
     out, _ = capsys.readouterr()
-    assert "Depositing" in out and "Withdrawing" in out
+    assert "Deposited" in out and "Withdrew" in out
+
+    state = load_state()
+    assert state["total_assets"] == pytest.approx(5.0)
+    assert state["total_shares"] == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- track fund state in a JSON file via new `state` module
- update CLI commands to deposit, withdraw, and show info using the state
- adjust `.gitignore`
- add CLI usage examples in README
- expand tests for stateful operations
- switch docs to use `uv` for dependency management
- lazily resolve state file path so tests can override it

## Testing
- `uv venv && uv pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879f09670308321ae871608784fc279

## Summary by Sourcery

Implement a persistent state-backed ledger for the fund CLI, replacing mocks with real deposit, withdraw, and info commands, and update documentation and tests to reflect stateful operations.

New Features:
- Introduce state module for loading and saving fund state in a JSON file
- Update CLI to perform real deposit, withdraw, and info operations on persistent state

Enhancements:
- Lazily resolve state file path using env var override and ensure directory creation
- Adjust .gitignore to ignore runtime state file

Documentation:
- Revise README to use UV for dependency management and include CLI usage examples

Tests:
- Expand tests to operate on a temporary state file and assert actual asset/share updates