### PR TITLE
Add admin page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ dependencies = [
   "web3>=6.17.0",
   "typer>=0.12.3",
   "python-dotenv>=1.0.0",
-  "loguru>=0.7.2"
+  "loguru>=0.7.2",
+  "fastapi>=0.111.0",
+  "uvicorn>=0.29.0",
+  "httpx>=0.27.0"
 ]
 
 # 선택(개발) 의존성 --------------------------------------------------
@@ -37,6 +40,7 @@ dev = [
 # CLI 엔트리포인트 ---------------------------------------------------
 [project.scripts]
 defi-cli = "defi_fund.cli.app:app"
+defi-admin = "defi_fund.web.admin:main"
 
 # ------------------------------------------------------------------
 # src 레이아웃을 setuptools에 알림

--- a/src/defi_fund/web/__init__.py
+++ b/src/defi_fund/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web interface components."""

--- a/src/defi_fund/web/admin.py
+++ b/src/defi_fund/web/admin.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from defi_fund.state import load_state
+
+app = FastAPI(title="DeFi Fund Admin")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> HTMLResponse:
+    state = load_state()
+    html = f"""
+    <html>
+        <head><title>DeFi Fund Admin</title></head>
+        <body>
+            <h1>Fund State</h1>
+            <ul>
+                <li>Total Assets: {state['total_assets']:.4f}</li>
+                <li>Total Shares: {state['total_shares']:.4f}</li>
+                <li>Mgmt Acc: {state['mgmt_acc']:.4f}</li>
+                <li>Perf Acc: {state['perf_acc']:.4f}</li>
+                <li>HWM: {state['hwm']:.4f}</li>
+            </ul>
+        </body>
+    </html>
+    """
+    return HTMLResponse(content=html)
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("defi_fund.web.admin:app", host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 from defi_fund.cli.app import deposit, withdraw
+from defi_fund.web.admin import app as admin_app
+from fastapi.testclient import TestClient
 from defi_fund.state import load_state
 import time
 
@@ -17,3 +19,14 @@ def test_deposit_and_withdraw(tmp_path, capsys, monkeypatch):
     state = load_state()
     assert state["total_assets"] == pytest.approx(5.0)
     assert state["total_shares"] == pytest.approx(5.0)
+
+
+def test_admin_page(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("FUND_STATE_FILE", str(state_file))
+    deposit(1.0)
+
+    client = TestClient(admin_app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Fund State" in resp.text


### PR DESCRIPTION
## Summary
- add FastAPI and uvicorn for web interface
- implement simple admin dashboard
- expose `defi-admin` script
- test admin page with FastAPI's TestClient

## Testing
- `uv venv && uv pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a15315ee8832189495ed4e4d7b481

## Summary by Sourcery

Add a FastAPI-based admin page to display fund state metrics and expose it via a new CLI script

New Features:
- Serve a simple HTML dashboard at the root URL via FastAPI displaying fund state metrics
- Add a `defi-admin` CLI command to launch the admin server with Uvicorn

Build:
- Add FastAPI, Uvicorn, and HTTPX to project dependencies

Tests:
- Add a TestClient-based test to verify the admin page responds with the fund state