### PR TITLE
Implement basic price oracle

### DIFF
--- a/src/defi_fund/cli/app.py
+++ b/src/defi_fund/cli/app.py
@@ -3,6 +3,8 @@ from loguru import logger
 from defi_fund.state import load_state, save_state
 from defi_fund.accounting import SPREAD_RATE, update_fees
 from defi_fund.txlog import log_transaction
+from defi_fund.oracle import get_price
+from defi_fund.config import settings
 
 app = typer.Typer(help="DeFi Fund CLI")
 
@@ -14,8 +16,10 @@ def deposit(amount: float):
     update_fees(state)
     fee = amount * SPREAD_RATE
     net_amount = amount - fee
-    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
-    new_shares = net_amount / price
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    share_price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
+    new_shares = (net_amount * asset_price) / share_price
     state["total_assets"] += net_amount
     state["total_shares"] += new_shares
     save_state(state)
@@ -33,8 +37,11 @@ def withdraw(shares: float):
     if shares > state["total_shares"]:
         typer.echo("Not enough shares", err=True)
         raise typer.Exit(code=1)
-    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
-    amount = shares * price
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    share_price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
+    amount_usd = shares * share_price
+    amount = amount_usd / asset_price
     fee = amount * SPREAD_RATE
     net_amount = amount - fee
     state["total_assets"] -= net_amount
@@ -60,7 +67,9 @@ def info():
     """펀드 정보 조회."""
     state = load_state()
     update_fees(state)
-    price = state["total_assets"] / state["total_shares"] if state["total_shares"] > 0 else 1.0
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
     typer.echo(
         f"Assets: {state['total_assets']:.4f}, Shares: {state['total_shares']:.4f}, Price: {price:.4f}, "
         f"MgmtAcc: {state['mgmt_acc']:.4f}, PerfAcc: {state['perf_acc']:.4f}, HWM: {state['hwm']:.4f}"

--- a/src/defi_fund/config/settings.py
+++ b/src/defi_fund/config/settings.py
@@ -8,3 +8,8 @@ load_dotenv(BASE_DIR / ".env")
 
 WEB3_PROVIDER_URI: str = os.getenv("WEB3_PROVIDER_URI", "http://localhost:8545")
 DEFAULT_GAS: int = int(os.getenv("DEFAULT_GAS", 250000))
+
+# Asset symbol accepted for deposits (used for price oracle lookup)
+DEPOSIT_ASSET: str = os.getenv("DEPOSIT_ASSET", "TOKEN")
+# Optional Chainlink price feed address for the deposit asset
+PRICE_FEED: str | None = os.getenv("PRICE_FEED")

--- a/src/defi_fund/oracle.py
+++ b/src/defi_fund/oracle.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+from web3 import Web3
+
+from .config import settings
+
+# Minimal Chainlink AggregatorV3 interface
+AGGREGATOR_ABI = [
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {"internalType": "uint8", "name": "", "type": "uint8"}
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "latestRoundData",
+        "outputs": [
+            {"internalType": "uint80", "name": "roundId", "type": "uint80"},
+            {"internalType": "int256", "name": "answer", "type": "int256"},
+            {"internalType": "uint256", "name": "startedAt", "type": "uint256"},
+            {"internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+            {"internalType": "uint80", "name": "answeredInRound", "type": "uint80"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+@lru_cache(maxsize=None)
+def _w3() -> Web3:
+    return Web3(Web3.HTTPProvider(settings.WEB3_PROVIDER_URI))
+
+
+def _price_from_chainlink(feed: str) -> float:
+    """Return latest price from a Chainlink aggregator."""
+    contract = _w3().eth.contract(address=feed, abi=AGGREGATOR_ABI)
+    answer = contract.functions.latestRoundData().call()[1]
+    decimals = contract.functions.decimals().call()
+    return float(answer) / 10 ** decimals
+
+
+def get_price(symbol: str, feed: Optional[str] = None) -> float:
+    """Get USD price for a token symbol."""
+    env_key = f"MOCK_PRICE_{symbol.upper()}"
+    if env_key in os.environ:
+        return float(os.environ[env_key])
+    feed = feed or settings.PRICE_FEED
+    if feed:
+        try:
+            return _price_from_chainlink(feed)
+        except Exception:
+            pass
+    # default to 1.0 if no feed or fetch fails
+    return 1.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ from defi_fund.cli.app import deposit, withdraw
 from defi_fund.web.admin import app as admin_app
 from fastapi.testclient import TestClient
 from defi_fund.state import load_state
+from defi_fund.oracle import get_price
 import time
 
 def test_deposit_and_withdraw(tmp_path, capsys, monkeypatch):
@@ -39,3 +40,9 @@ def test_admin_page(tmp_path, monkeypatch):
     resp = client.get("/", auth=("admin", "secret"))
     assert resp.status_code == 200
     assert "Fund State" in resp.text
+
+
+def test_oracle_env_override(monkeypatch):
+    monkeypatch.setenv("MOCK_PRICE_TOKEN", "2.0")
+    price = get_price("TOKEN")
+    assert price == 2.0


### PR DESCRIPTION
## Summary
- add Chainlink price oracle helper
- support price-aware share calculations in CLI
- expose deposit asset config
- test oracle env override

## Testing
- `uv venv && uv pip install -e '.[dev]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8728e498832181d08f100a080acb

## Summary by Sourcery

Implement a basic price oracle helper with Chainlink integration and env-based mocking, expose deposit asset and price feed configuration, update CLI commands to perform price-aware share calculations, and add a test for oracle environment override.

New Features:
- Add price oracle module to fetch USD prices from Chainlink or environment variables

Enhancements:
- Update CLI deposit, withdraw, and info commands to calculate shares and amounts using asset USD price
- Expose DEPOSIT_ASSET and PRICE_FEED settings for configurable deposit asset and optional price feed

Tests:
- Add test for mocking oracle price via environment variable override