### PR TITLE
Add basic web frontend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 [project.scripts]
 defi-cli = "defi_fund.cli.app:app"
 defi-admin = "defi_fund.web.admin:main"
+defi-web = "defi_fund.web.frontend:main"
 
 # ------------------------------------------------------------------
 # src 레이아웃을 setuptools에 알림

--- a/src/defi_fund/web/frontend.py
+++ b/src/defi_fund/web/frontend.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from defi_fund.state import load_state, save_state
+from defi_fund.accounting import SPREAD_RATE, update_fees
+from defi_fund.txlog import log_transaction
+from defi_fund.oracle import get_price
+from defi_fund.config import settings
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+
+app = FastAPI(title="DeFi Fund Frontend")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/", response_class=FileResponse)
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+class DepositRequest(BaseModel):
+    amount: float
+
+
+@app.post("/api/deposit")
+def api_deposit(req: DepositRequest) -> dict:
+    state = load_state()
+    update_fees(state)
+    fee = req.amount * SPREAD_RATE
+    net_amount = req.amount - fee
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    share_price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
+    new_shares = (net_amount * asset_price) / share_price
+    state["total_assets"] += net_amount
+    state["total_shares"] += new_shares
+    save_state(state)
+    log_transaction("deposit", req.amount)
+    return {"new_shares": new_shares, "fee": fee}
+
+
+class WithdrawRequest(BaseModel):
+    shares: float
+
+
+@app.post("/api/withdraw")
+def api_withdraw(req: WithdrawRequest) -> dict:
+    state = load_state()
+    update_fees(state)
+    if req.shares > state["total_shares"]:
+        raise HTTPException(status_code=400, detail="Not enough shares")
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    share_price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
+    amount_usd = req.shares * share_price
+    amount = amount_usd / asset_price
+    fee = amount * SPREAD_RATE
+    net_amount = amount - fee
+    state["total_assets"] -= net_amount
+    state["total_shares"] -= req.shares
+    save_state(state)
+    log_transaction("withdraw", req.shares)
+    return {"amount": net_amount, "fee": fee}
+
+
+@app.get("/api/state")
+def api_state() -> dict:
+    state = load_state()
+    update_fees(state)
+    asset_price = get_price(settings.DEPOSIT_ASSET)
+    nav_usd = state["total_assets"] * asset_price
+    price = nav_usd / state["total_shares"] if state["total_shares"] > 0 else asset_price
+    return {
+        "total_assets": state["total_assets"],
+        "total_shares": state["total_shares"],
+        "share_price": price,
+        "mgmt_acc": state["mgmt_acc"],
+        "perf_acc": state["perf_acc"],
+        "hwm": state["hwm"],
+    }
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("defi_fund.web.frontend:app", host="0.0.0.0", port=8080)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/defi_fund/web/static/index.html
+++ b/src/defi_fund/web/static/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>DeFi Fund Dashboard</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/javascript">
+    const e = React.createElement;
+    function App() {
+        const [state, setState] = React.useState(null);
+        const [amount, setAmount] = React.useState("");
+        const [shares, setShares] = React.useState("");
+        const refresh = () => fetch('/api/state').then(r=>r.json()).then(setState);
+        React.useEffect(refresh, []);
+        const doDeposit = () => {
+            fetch('/api/deposit', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({amount:parseFloat(amount)})})
+                .then(refresh);
+        };
+        const doWithdraw = () => {
+            fetch('/api/withdraw', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({shares:parseFloat(shares)})})
+                .then(refresh);
+        };
+        if(!state) return e('div', null, 'Loading...');
+        return e('div', null,
+            e('h1', null, 'DeFi Fund Dashboard'),
+            e('p', null, `Assets: ${state.total_assets.toFixed(4)}`),
+            e('p', null, `Shares: ${state.total_shares.toFixed(4)}`),
+            e('p', null, `Share Price: ${state.share_price.toFixed(4)}`),
+            e('div', null,
+                e('input', {value: amount, onChange: ev => setAmount(ev.target.value), placeholder: 'amount'}),
+                e('button', {onClick: doDeposit}, 'Deposit')
+            ),
+            e('div', null,
+                e('input', {value: shares, onChange: ev => setShares(ev.target.value), placeholder: 'shares'}),
+                e('button', {onClick: doWithdraw}, 'Withdraw')
+            )
+        );
+    }
+    ReactDOM.createRoot(document.getElementById('root')).render(e(App));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a FastAPI server for dApp interactions
- expose deposit, withdraw and state API routes
- serve a minimal React dashboard
- register `defi-web` entrypoint
- test API endpoints

## Testing
- `uv pip install -e '.[dev]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b96cd7b08832198f52d61ed9a6e02

## Summary by Sourcery

Add a basic web frontend with FastAPI endpoints for deposit, withdraw, and state operations, serve a minimal React dashboard, register a new CLI entrypoint, and include API integration tests.

New Features:
- Expose deposit, withdraw, and state REST API endpoints using FastAPI
- Serve a minimal React dashboard and mount static frontend assets
- Register a new "defi-web" CLI entrypoint for launching the web server

Build:
- Register the "defi-web" script entrypoint in pyproject.toml

Tests:
- Add integration tests for the web API endpoints covering deposit and state retrieval