### PR TITLE
Expand accounting tests

### DIFF
--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -1,0 +1,64 @@
+import math
+import time
+import pytest
+
+from defi_fund.accounting import (
+    MGMT_RATE,
+    PERF_RATE,
+    YEAR_SECONDS,
+    accrue_management_fee,
+    accrue_performance_fee,
+    settle_fees,
+)
+
+
+def test_performance_fee_and_hwm():
+    state = {
+        "total_assets": 120.0,
+        "total_shares": 100.0,
+        "mgmt_acc": 0.0,
+        "perf_acc": 0.0,
+        "hwm": 1.0,
+        "last_update": 0.0,
+    }
+    accrue_performance_fee(state)
+    expected_perf = (1.2 - 1.0) * 100.0 * PERF_RATE
+    assert state["perf_acc"] == pytest.approx(expected_perf)
+    assert state["hwm"] == pytest.approx(1.2)
+
+    settle_fees(state)
+    expected_shares = 100.0 + expected_perf / 1.2
+    assert state["total_shares"] == pytest.approx(expected_shares)
+    assert state["perf_acc"] == 0.0
+
+
+def test_management_fee_over_time():
+    state = {
+        "total_assets": 100.0,
+        "total_shares": 100.0,
+        "mgmt_acc": 0.0,
+        "perf_acc": 0.0,
+        "hwm": 1.0,
+        "last_update": 0.0,
+    }
+    accrue_management_fee(state, timestamp=YEAR_SECONDS)
+    expected_mgmt = 100.0 * MGMT_RATE
+    assert state["mgmt_acc"] == pytest.approx(expected_mgmt)
+
+    settle_fees(state)
+    assert state["mgmt_acc"] == 0.0
+    assert state["total_shares"] == pytest.approx(100.0 + expected_mgmt / 1.0)
+
+
+def test_extreme_profit_no_overflow():
+    state = {
+        "total_assets": 1e9,
+        "total_shares": 1.0,
+        "mgmt_acc": 0.0,
+        "perf_acc": 0.0,
+        "hwm": 1.0,
+        "last_update": 0.0,
+    }
+    accrue_performance_fee(state)
+    assert math.isfinite(state["perf_acc"])
+    assert state["hwm"] == pytest.approx(1e9)

--- a/tests/test_cli_flow.py
+++ b/tests/test_cli_flow.py
@@ -1,0 +1,28 @@
+import time
+import pytest
+
+from defi_fund.cli.app import deposit, withdraw, crystallize
+from defi_fund.state import load_state
+from defi_fund.accounting import YEAR_SECONDS
+
+
+def test_crystallize_after_multiple_actions(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    tx_file = tmp_path / "tx.csv"
+    monkeypatch.setenv("FUND_STATE_FILE", str(state_file))
+    monkeypatch.setenv("FUND_TX_LOG", str(tx_file))
+
+    monkeypatch.setattr(time, "time", lambda: 0)
+    deposit(10.0)
+
+    monkeypatch.setattr(time, "time", lambda: YEAR_SECONDS // 2)
+    deposit(5.0)
+    withdraw(3.0)
+
+    monkeypatch.setattr(time, "time", lambda: YEAR_SECONDS)
+    crystallize()
+
+    state = load_state()
+    assert state["mgmt_acc"] == pytest.approx(0.0)
+    assert state["perf_acc"] == pytest.approx(0.0)
+    assert state["total_shares"] > 0


### PR DESCRIPTION
## Summary
- add unit tests for accounting functions covering HWM and management fees
- add cli flow test exercising crystallize

## Testing
- `uv venv`
- `uv pip install -e '.[dev]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b99f97fac8321bdd6e3233576a397

## Summary by Sourcery

Add comprehensive tests for accounting logic and CLI crystallization flow

Tests:
- Add unit tests for performance fee accrual, high-water-mark updates, management fee accrual over time, and extreme-profit overflow protection
- Add integration test for CLI operations including deposit, withdrawal, and crystallize, verifying fee settlement and share calculations